### PR TITLE
Add git delete-merged-on-origin alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ git csquash <commit> = commit --squash <commit>
 git track-origin-same-branch-name = !git branch --set-upstream-to=origin/`git symbolic-ref --short HEAD`
 	- sets current branch tracking to origin/<name-of-current-branch>
 
+git delete-merged-on-origin = !git branch --all --merged remotes/origin/master | grep --invert-match master | grep --invert-match HEAD | grep "remotes/origin/" | cut -d "/" -f 3- | xargs -n 1 git push --delete origin --dry-run
+	- delete all branches on remote "origin" that have been merged into "origin/master"
+
 # gpr 96, will fetch PR 96 create branch pull-request-96
 gpr () { git fetch origin pull/$1/head:pull-request-$1; }
 ```
@@ -171,6 +174,7 @@ you can delete the directory and contents `~/ironcode-git-enhancements`
 
 Changelog
 ------------
+* 20171124 - Add `git delete-merged-on-origin` to delete all branches on remote `origin` that have been merged into `origin/master` ([#62](https://github.com/ironcodestudio/ironcode-git-enhancements/issues/62))
 * 20171102 - Add `git track-origin-same-branch-name` to set the current branch to track `origin/<name-of-current-branch>`. This is useful when faced with the "no tracking information for the current branch" message ([#49](https://github.com/ironcodestudio/ironcode-git-enhancements/issues/49))
 * 20170929 - Add `git d-` and `gd-` to delete previous branch ([#56](https://github.com/ironcodestudio/ironcode-git-enhancements/issues/56))
 * 20170929 - Add git move to move the most recent commit(s) to another branch ([#52](https://github.com/ironcodestudio/ironcode-git-enhancements/issues/52))

--- a/gitconfig
+++ b/gitconfig
@@ -11,6 +11,10 @@
 	csquash = commit --squash
 	track-origin-same-branch-name = !git branch --set-upstream-to=origin/`git symbolic-ref --short HEAD`
 
+	# Delete all branches on remote `origin` that have been
+	# merged into `origin/master`
+	delete-merged-on-origin = !git branch --all --merged remotes/origin/master | grep --invert-match master | grep --invert-match HEAD | grep "remotes/origin/" | cut -d "/" -f 3- | xargs -n 1 git push --delete origin --dry-run
+
 	# Delete previous branch.
 	d- = branch -d @{-1}
 


### PR DESCRIPTION
Add git delete-merged-on-origin alias to delete all branches on remote "origin"
that have been merged into "origin/master"

```
git delete-merged-on-origin
```

See #62