### PR TITLE
Add FeDeleteRemoteBranch and drb aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add CHANGELOG.md file
+- Add alias git drb to delete a remote branch
 
 ## [1.3.0] - 2018-01-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ git lg     = Display pretty color one-line log with branches, commits, and tags.
 
 git d-     = Delete Previous branch
 
+git drb <branchname> = Delete branch from remote origin
+	- branchname defaults to currently active local branch name
+
 git pf     = Push --force-with-lease
 
 git branch-clean = Remove both:

--- a/gitconfig
+++ b/gitconfig
@@ -13,6 +13,13 @@
 	FeTrackingRemoteByLocalBranchName     = "!f() { git "config branch.$1.remote"; }; f"
 	FeTrackingBranchNameByLocalBranchName = "!f() { git "config branch.$1.merge"; }; f"
 
+	# Delete the remote branch on origin with the given branch name,
+	# if no branch name is given, the current branch is used.
+	FeDeleteRemoteBranch = "!f() {               \
+		branch=${1-"`git FeCurrentBranchName`"}; \
+		git push origin --delete $branch;        \
+	}; f"
+
 	#########################
 	# END: Helper Aliases   #
 	#########################
@@ -32,6 +39,9 @@
 
 	# Delete previous branch.
 	d- = branch -d @{-1}
+
+	# Delete remote branch on origin. Optional param of branch to delete, defaults to current branch.
+	drb = !git FeDeleteRemoteBranch ${1}
 
 	# Delete the remote tracking branch associated with the given local branch,
 	# if no branch name is given, the current branch is used.


### PR DESCRIPTION
Both do the same thing.  Delete the given branch name from the remote
origin (if no branch name is given, the currently active local branch is
used).

See #70