### PR TITLE
Add gd based git add aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add alias 'agd' for git add
+- Add alias 'apgd' for git add -p
 
 ## [1.4.1] - 2018-02-24
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Git Shortcuts
 alias gs   = 'git status'
 alias gsi  = 'git status --ignored'
 alias ga   = 'git add'
+alias agd  = 'git add'
+alias apgd = 'git add -p'
 alias gb   = 'git branch'
 alias gbv  = 'git branch -a -v' # shows both local and remote branches AND verbose
 alias gc   = 'git commit --verbose'

--- a/bash_profile-mods.bash
+++ b/bash_profile-mods.bash
@@ -69,6 +69,10 @@ __git_shortcut  gsi   status "--ignored --short"
 
 __git_shortcut  ga    add
 
+__git_shortcut  agd   add
+
+__git_shortcut  apgd  add -p
+
 __git_shortcut  gb    branch
 
 __git_shortcut  gbv   branch "-a -v"


### PR DESCRIPTION
Because I often git diff (using gd alias) a file and then add it, e.g.

gd src/myclass.php
git add src/myclass.php

I've added an alias for "git add" based on "gd", this allows me to use
the up arrow to populate the command line. e.g.

gd src/myclass.php
(up arrow auto-populating the last line)
(now I jump to the begining of the line with CTRL+a)
(and add "a" for add)
agd src/myclass.php

Along the same lines, sometimes I want to use "git add -p" in the same way,
which is why we have the "apgd" alias.

See #81