### PR TITLE
Add alias 'gdsno' for git diff --staged --name-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add alias 'agd' for git add
 - Add alias 'apgd' for git add -p
+- Add alias 'gdsno' for git diff --staged --name-only
 
 ## [1.4.1] - 2018-02-24
 ### Changed

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ alias gc   = 'git commit --verbose'
 alias gd   = 'git diff'
 alias gds  = 'git diff --staged'
 alias gdno = 'git diff --name-only'
+alias gdsno = 'git diff --staged --name-only'
 alias go   = 'git checkout'
 alias gl   = 'git lg' # Mapped to custom alias
 alias gd-  = 'git d-' # Mapped to custom alias

--- a/bash_profile-mods.bash
+++ b/bash_profile-mods.bash
@@ -87,6 +87,8 @@ __git_shortcut  gds   diff --staged
 
 __git_shortcut  gdno  diff --name-only
 
+__git_shortcut  gdsno diff "--staged --name-only"
+
 __git_shortcut  go    checkout
 
 __git_shortcut  gl    lg # Mapped to custom alias, pretty one-line log.


### PR DESCRIPTION
We already have aliases:

- gds (git diff --staged)
- gdno (git diff --name-only)

This new alias combines this two for

git diff --staged --name-only

This is useful when you want to see a list of files currently staged
(without seeing the actual changes in those files).

Fixes #73