### PR TITLE
Add tab completion function for git lg (and gl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add tab completion for `gl`
 - Add alias `git branch-delete-merged` / `gbdm` to delete local branches already merged into current branch
 
 ## [1.5.0] - 2018-10-30

--- a/bash_profile-mods.bash
+++ b/bash_profile-mods.bash
@@ -93,6 +93,12 @@ __git_shortcut  gdsno diff "--staged --name-only"
 
 __git_shortcut  go    checkout
 
+# Add tab completion for git lg, which behaves the same as tab completion for
+# git log. Tab completion for git lg works without this function, however
+# tab completion for `gl` needs this function.
+function _git_lg() {
+  _git_log
+}
 __git_shortcut  gl    lg # Mapped to custom alias, pretty one-line log.
 
 __git_shortcut  gd-   d- # Mapped to custom alias, delete previous branch.


### PR DESCRIPTION
This tab completion function is not necessary for git lg, since the
completion function for git log will be automatically used. However,
since our __git_shortcut() function in bash looks for the appropriate
autocomplete function when creating a bash alias, we need this function
to get the autocompletion for gl to work properly.

See #95