### PR TITLE
Add --verbose behavior to all commit commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Modify `git lg` to use Y-m-d H:M:S local time (instead of relative time)
+- Set gitconfig commit.verbose=true so all commit commands behavior as if they have the `--verbose` flag
 
 ## [1.6.0] - 2019-05-16
 ### Added

--- a/bash_profile-mods.bash
+++ b/bash_profile-mods.bash
@@ -79,9 +79,9 @@ __git_shortcut  gbdm  branch-delete-merged
 
 __git_shortcut  gbv   branch "-a -v"
 
-__git_shortcut  gc    commit --verbose
+__git_shortcut  gc    commit
 
-__git_shortcut  gca   commit "--amend --verbose"
+__git_shortcut  gca   commit "--amend"
 
 __git_shortcut  gcb   current-branch
 

--- a/gitconfig
+++ b/gitconfig
@@ -107,6 +107,9 @@
 			fi                                                           \
 		fi'";
 
+[commit]
+	verbose = true
+
 [push]
 	# push only the current branch to the remote (and create the branch
 	# on the remote if it does not already exist there)


### PR DESCRIPTION
Add to gitconfig `commit.verbose=true` to add `--verbose` behavior to all commit commands

See https://salferrarello.com/git-preview-changes-in-commit-message/

See #104 