### PR TITLE
Add "git jira" command

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -89,6 +89,11 @@
 		git cherry-pick @{-1}~${1:-1}...@{-1}~0;   \
 	}; f"
 
+	jira = "!f() { \
+		jiraBaseUrl=\"https://$(git config --get salcode.jiraSubdomain).atlassian.net/browse/\"; \
+		open $jiraBaseUrl$(git rev-parse --abbrev-ref HEAD | sed 's/^.*\\/\\([a-zA-z]\\{1,\\}-[0-9]\\{1,\\}\\).*/\\1/'); \
+	}; f"
+
 	# Move to the given branch the last n commits.
 	# @param string $1 The destination branch (create if does not exist).
 	# @param int    $2 The number of commits to move. Defaults to 1.


### PR DESCRIPTION
The `git jira` command parses the branch name to determine the Jira
issue based on the naming s
`{branchType}/{issue}-{description}`
e.g. `feature/sf-123-add-new-button` (the issue number is `sf-123`)

The git jira command uses this issue number in combination with the
custom git config value stored at `salcode.jiraSubdomain` (in my example
this value is `ferrarello`) to construct a
URL like

```
https://ferrarello.atlassian.net/browse/sf-123
```

and open this URL in the browser.

See #118