### PR TITLE
Add tab completion cue line to can-ff-merge alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add `git open-pr-github` to open the default web browser to the GitHub URL to create a Pull Request (PR) for the current branch
 
+### Fixed
+- Add tab completion cue to `git can-ff-merge` for branch completion option instead of file names
+
 ## [2.1.0] - 2021-03-13
 ### Added
 - Add `git recover-rejected-commit` to open the editor to create a commit and pre-populate the commit message with the contents of .git/COMMIT_EDITMSG

--- a/gitconfig
+++ b/gitconfig
@@ -30,6 +30,7 @@
 	branch-delete-merged = !git branch --merged | grep -Ev \"(^\\*|^\\s+master$)\" | xargs git branch -d
 
 	can-ff-merge = "!f() {                                              \
+		: git branch ; \
 		[ -e "${1}" ] && echo "Missing branch name to merge" && exit 1; \
 		git "merge-base --is-ancestor                                   \
 			$(git branch --show-current) ${1}"                          \


### PR DESCRIPTION
Add tab completion cue line (git branch) to can-ff-merge alias, to
displays branches on tab completion instead of files.

Resolves #136