### PR TITLE
Add optional target branch argument to "open-pr-github" alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Added
-- Add `git open-pr-github` to open the default web browser to the GitHub URL to create a Pull Request (PR) for the current branch
+- Add `git open-pr-github [target]` to open the default web browser to the GitHub URL to create a Pull Request (PR) for the current branch (into the "target" branch if given, otherwise the repo default branch is used as the target)
 
 ### Fixed
 - Add tab completion cue to `git can-ff-merge` for branch completion option instead of file names

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ git can-ff-merge <branchName>
 
 # Open the default web browser to the GitHub URL
 # to create a Pull Request (PR) for the current branch
-git open-pr-github
+# into the "target" branch (or into the default
+# branch if "target" is omitted)
+git open-pr-github [<target>]
 
 # Populate a new git commit message with the contents of .git/COMMIT_EDITMSG
 # This is helpful when the git commit-msg hook fails.

--- a/gitconfig
+++ b/gitconfig
@@ -119,10 +119,16 @@
 	recover-rejected-commit = "!f() { git "commit -e --file=$(git rev-parse --git-dir)/COMMIT_EDITMSG"; }; f"
 
 	open-pr-github = "!f() { \
+		if [[ -z $1 ]]; \
+		then \
+			target=''; \
+		else \
+			target=\"$1...\"; \
+		fi; \
 		open \"$(git ls-remote --get-url $(git config --get branch.$(git branch --show-current).remote) \
 			| sed 's|git@github.com:\\(.*\\)$|https://github.com/\\1|' \
 			| sed 's|\\.git$||'; \
-		)/compare/$(\
+		)/compare/$target$(\
 		git config --get branch.$(git branch --show-current).merge | cut -d '/' -f 3- \
 		)?expand=1\"; \
 	}; f"

--- a/gitconfig
+++ b/gitconfig
@@ -119,6 +119,7 @@
 	recover-rejected-commit = "!f() { git "commit -e --file=$(git rev-parse --git-dir)/COMMIT_EDITMSG"; }; f"
 
 	open-pr-github = "!f() { \
+		: git branch ; \
 		if [[ -z $1 ]]; \
 		then \
 			target=''; \


### PR DESCRIPTION
This PR maintains the existing behavior where

git open-pr-github

opens the GitHub URL to create a PR from the
current branch into the repo's default branch.


In addition, the command now accepts an argument
for the target (a.k.a. base) branch.

git open-pr-github my-branch

will now open a the GitHub URL to create a PR from
the current branch into the given branch ("my-branch")

Resolves #139 